### PR TITLE
Fix wrong MAC address value in returned Result

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -198,9 +198,11 @@ func (m *manager) SetupVF(conf *types.NetConf, podifName, cid string, netns ns.N
 		return "", fmt.Errorf("error setting temp IF name %s for %s", tempName, linkName)
 	}
 
+	macAddress := linkObj.Attrs().HardwareAddr.String()
 	// 3. Set MAC address
 	if conf.MAC != "" {
 		hwaddr, err := net.ParseMAC(conf.MAC)
+		macAddress = conf.MAC
 		if err != nil {
 			return "", fmt.Errorf("failed to parse MAC address %s: %v", conf.MAC, err)
 		}
@@ -218,8 +220,6 @@ func (m *manager) SetupVF(conf *types.NetConf, podifName, cid string, netns ns.N
 		return "", fmt.Errorf("failed to move IF %s to netns: %q", tempName, err)
 	}
 
-	var macAddress string
-
 	if err := netns.Do(func(_ ns.NetNS) error {
 		// 5. Set Pod IF name
 		if err := m.nLink.LinkSetName(linkObj, podifName); err != nil {
@@ -231,7 +231,6 @@ func (m *manager) SetupVF(conf *types.NetConf, podifName, cid string, netns ns.N
 			return fmt.Errorf("error bringing interface up in container ns: %q", err)
 		}
 
-		macAddress = linkObj.Attrs().HardwareAddr.String()
 		return nil
 	}); err != nil {
 		return "", fmt.Errorf("error setting up interface in container namespace: %q", err)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -118,6 +118,33 @@ var _ = Describe("Manager", func() {
 			Expect(macAddr).To(Equal("6e:16:06:0e:b7:e9"))
 			mocked.AssertExpectations(t)
 		})
+		It("Setting mac address", func() {
+			targetNetNS := newFakeNs()
+			mocked := &mocks.NetlinkManager{}
+			fakeMac, err := net.ParseMAC("6e:16:06:0e:b7:e9")
+			Expect(err).NotTo(HaveOccurred())
+			netconf.MAC = "e4:11:22:33:44:55"
+			expMac, err := net.ParseMAC(netconf.MAC)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeLink := &FakeLink{netlink.LinkAttrs{
+				Index:        1000,
+				Name:         "dummylink",
+				HardwareAddr: fakeMac,
+			}}
+
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, mock.Anything).Return(nil)
+			mocked.On("LinkSetHardwareAddr", fakeLink, expMac).Return(nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			mocked.On("LinkSetUp", fakeLink).Return(nil)
+			m := manager{nLink: mocked}
+			macAddr, err := m.SetupVF(netconf, podifName, contID, targetNetNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macAddr).To(Equal(netconf.MAC))
+			mocked.AssertExpectations(t)
+		})
 	})
 
 	Context("Checking ReleaseVF function", func() {


### PR DESCRIPTION
According to CNI Convention MAC address returned in the Result is the
one configured by the plugin, but plugin return initial VF's MAC addr
even if it was passed in cni config.
MAC address value, returned by SetupVF function, assigned from the
linkObj after mac address was setted. That's not correct, since linkObj
don't point directly to underlying kernel's netlink object, so mac
address still has initial value.
Fix that by doing correct assignments.

Fix: #3
Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>