### PR TITLE
Automatically add PF to the bridge and configure VLAN on it

### DIFF
--- a/cmd/accelerated-bridge/main.go
+++ b/cmd/accelerated-bridge/main.go
@@ -89,12 +89,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 	defer netns.Close()
 
 	m := manager.NewManager()
-	if err = m.AttachRepresentor(netConf); err != nil {
-		return fmt.Errorf("failed to attach representor: %v", err)
+	if err = m.AddToBridge(netConf); err != nil {
+		return fmt.Errorf("failed to add required configuration for bridge: %v", err)
 	}
 	defer func() {
 		if err != nil {
-			_ = m.DetachRepresentor(netConf)
+			_ = m.DelFromBridge(netConf)
 		}
 	}()
 
@@ -206,8 +206,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	m := manager.NewManager()
 
-	if err = m.DetachRepresentor(netConf); err != nil {
-		log.Warn().Msgf("failed to detach representor: %v", err)
+	if err = m.DelFromBridge(netConf); err != nil {
+		log.Warn().Msgf("failed to remove configuration from bridge: %v", err)
 	}
 
 	if netConf.IPAM.Type != "" {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -439,6 +439,9 @@ func (m *manager) addRepresentorToBridge(bridge netlink.Link, conf *types.NetCon
 		if err = m.nLink.BridgeVlanAdd(rep, uint16(conf.Vlan), true, true, false, true); err != nil {
 			return fmt.Errorf("failed to set VLAN for representor %s: %v", conf.Representor, err)
 		}
+		if err = m.nLink.BridgeVlanDel(rep, uint16(1), true, true, false, true); err != nil {
+			return fmt.Errorf("failed to remove default (1) VLAN for representor %s: %v", conf.Representor, err)
+		}
 	}
 
 	if err = m.nLink.LinkSetUp(rep); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -400,6 +400,11 @@ func (m *manager) addPFToBridge(bridge netlink.Link, conf *types.NetConf) error 
 	if err = m.nLink.LinkSetMaster(pf, bridge); err != nil {
 		return fmt.Errorf("failed to add PF %s to bridge: %v", conf.Master, err)
 	}
+	if conf.Vlan != 0 {
+		if err = m.nLink.BridgeVlanAdd(pf, uint16(conf.Vlan), false, false, false, true); err != nil {
+			return fmt.Errorf("failed to add VLAN for PF %s: %v", conf.Master, err)
+		}
+	}
 	if err = m.nLink.LinkSetUp(pf); err != nil {
 		return fmt.Errorf("failed to set PF %s up: %v", conf.Master, err)
 	}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -332,6 +332,7 @@ var _ = Describe("Manager", func() {
 				link.Attrs().MasterIndex = bridge.Attrs().Index
 			}).Return(nil)
 			mockedNl.On("BridgeVlanAdd", fakeLink, uint16(100), true, true, false, true).Return(nil)
+			mockedNl.On("BridgeVlanDel", fakeLink, uint16(1), true, true, false, true).Return(nil)
 			mockedNl.On("BridgeVlanAdd", fakePF, uint16(100), false, false, false, true).Return(nil)
 			m := manager{nLink: mockedNl, sriov: mockedSr}
 			err := m.AddToBridge(netconf)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -332,6 +332,7 @@ var _ = Describe("Manager", func() {
 				link.Attrs().MasterIndex = bridge.Attrs().Index
 			}).Return(nil)
 			mockedNl.On("BridgeVlanAdd", fakeLink, uint16(100), true, true, false, true).Return(nil)
+			mockedNl.On("BridgeVlanAdd", fakePF, uint16(100), false, false, false, true).Return(nil)
 			m := manager{nLink: mockedNl, sriov: mockedSr}
 			err := m.AddToBridge(netconf)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
To enable offloading VF representor and PF should must be added to the same bridge.

This PR add logic to automatically add PF to a bridge.

Need to discuss this change before merge.