### PR TITLE
Add support for VLAN trunk

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -10,6 +10,24 @@ The Accelerated Bridge CNI configures networks through a CNI spec configuration 
 * `deviceID` (string, required): A valid pci address of a SWITCHDEV NIC's VF. e.g. "0000:03:02.3".
 * `vlan` (int, optional): VLAN ID to assign for the VF. Value must be in the range 0-4094 (0 for disabled, 1-4094 for valid VLAN IDs).
 * `mac` (string, optional): MAC address to assign for the VF
+* `trunk` (array, optional): VLAN trunk configuration for the VF. 
+  Value must be an array of objects with trunk config, e.g.
+  `[{"id": 42}, {"minID": 100, "maxID": 105}, {"minID": 200, "maxID": 210]`,
+  which means that trunk will allow folowing VLANs 42,100-105,200-210
+
+Default VLAN (1) will be used for VF if `vlan` and `trunk` options are not configured.
+In this case bridge expect untagged frames from VF and will drop all tagged frames.
+
+
+It is also possible to use `vlan` and `trunk` options together. 
+In this case, VLAN ID from `vlan` option will be used as
+"native" VLAN for VF. This means that bridge will add tag from `vlan` option to
+all untagged frames from VF and allow VF to send tagged frames with tags from `trunk` option.
+
+
+_Note: Accelerated Bridge CNI manages VLANs configuration for VF representor ports only.
+Which VLAN tag will be used when packet sent to wire also depends on Linux Bridge configuration (e.g. vlan_filtering option)
+and VLAN configuration for PF. CNI plugin doesn't manage these settings._
 
 
 An Accelerated Bridge CNI config with each field filled out looks like:
@@ -20,8 +38,9 @@ An Accelerated Bridge CNI config with each field filled out looks like:
     "name": "some-net",
     "type": "accelerated-bridge",
     "deviceID": "0000:03:02.0",
+    "mac": "CA:FE:C0:FF:EE:00",
     "vlan": 1000,
-    "mac": "CA:FE:C0:FF:EE:00"
+    "trunk": [{"minID": 100, "maxID": 105}]
 }
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,14 @@ func LoadConf(bytes []byte) (*localtypes.PluginConf, error) {
 		return nil, fmt.Errorf("vlan id %d invalid: value must be in the range 0-4094", conf.Vlan)
 	}
 
+	// validate trunk settings
+	if len(conf.NetConf.Trunk) > 0 {
+		conf.Trunk, err = splitVlanIds(conf.NetConf.Trunk)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return conf, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,6 +13,8 @@ var _ = Describe("Config", func() {
         "type": "accelerated-bridge",
         "deviceID": "0000:af:06.1",
         "vf": 0,
+		"vlan": 100,
+		"trunk" : [ { "id" : 42 }, { "minID" : 1000, "maxID" : 1010 } ],
         "ipam": {
             "type": "host-local",
             "subnet": "10.55.206.0/26",
@@ -61,6 +63,68 @@ var _ = Describe("Config", func() {
 			_, err := LoadConf(conf)
 			Expect(err).To(HaveOccurred())
 		})
+	})
+	It("Assuming correct config file - complex trunk config", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"trunk" : [{ "id" : 5 }, { "id": 19, "minID" : 101, "maxID" : 103 }, {"id": 55}, { "minID" : 20, "maxID" : 23 }]
+		}`)
+		cfg, err := LoadConf(conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Trunk).To(BeEquivalentTo([]int{5, 19, 20, 21, 22, 23, 55, 101, 102, 103}))
+
+	})
+	It("Assuming incorrect config file - negative vlan ID", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"vlan" : -222
+		}`)
+		_, err := LoadConf(conf)
+		Expect(err).To(HaveOccurred())
+	})
+	It("Assuming incorrect config file - vlan ID to large", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"vlan" : 4095
+		}`)
+		_, err := LoadConf(conf)
+		Expect(err).To(HaveOccurred())
+	})
+	It("Assuming incorrect config file - trunk minID more that maxID", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"trunk" : [ { "minID" : 1000, "maxID" : 50 } ]
+		}`)
+		_, err := LoadConf(conf)
+		Expect(err).To(HaveOccurred())
+	})
+	It("Assuming incorrect config file - trunk negative id", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"trunk" : [ { "id" : -1000 } ]
+		}`)
+		_, err := LoadConf(conf)
+		Expect(err).To(HaveOccurred())
+	})
+	It("Assuming incorrect config file - trunk invalid range", func() {
+		conf := []byte(`{
+        "name": "mynet",
+        "type": "accelerated-bridge",
+        "deviceID": "0000:af:06.1",
+		"trunk" : [ { "minID" : 4000, "maxID": 5000 } ]
+		}`)
+		_, err := LoadConf(conf)
+		Expect(err).To(HaveOccurred())
 	})
 	Context("Checking getVfInfo function", func() {
 		It("Assuming existing PF", func() {

--- a/pkg/config/vlan.go
+++ b/pkg/config/vlan.go
@@ -1,0 +1,67 @@
+// Copyright 2021 NVIDIA CORPORATION
+// Copyright 2018-2019 Red Hat, Inc.
+// Copyright 2014 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/Mellanox/accelerated-bridge-cni/pkg/types"
+)
+
+func splitVlanIds(trunks []types.Trunk) ([]int, error) {
+	vlans := make(map[int]bool)
+	for _, item := range trunks {
+		var minID, maxID, id int
+		if item.MinID != nil {
+			minID = *item.MinID
+			if minID < 0 || minID > 4096 {
+				return nil, errors.New("incorrect trunk minID parameter")
+			}
+		}
+		if item.MaxID != nil {
+			maxID = *item.MaxID
+			if maxID < 0 || maxID > 4096 {
+				return nil, errors.New("incorrect trunk maxID parameter")
+			}
+			if maxID < minID {
+				return nil, errors.New("minID is greater than maxID in trunk parameter")
+			}
+		}
+		if minID > 0 && maxID > 0 {
+			for v := minID; v <= maxID; v++ {
+				vlans[v] = true
+			}
+		}
+		if item.ID != nil {
+			id = *item.ID
+			if id < 0 || minID > 4096 {
+				return nil, errors.New("incorrect trunk id parameter")
+			}
+			vlans[id] = true
+		}
+	}
+	if len(vlans) == 0 {
+		return nil, errors.New("trunk parameter is misconfigured")
+	}
+	vlanIds := make([]int, 0, len(vlans))
+	for k := range vlans {
+		vlanIds = append(vlanIds, k)
+	}
+	sort.Slice(vlanIds, func(i, j int) bool { return vlanIds[i] < vlanIds[j] })
+	return vlanIds, nil
+}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -309,6 +309,7 @@ var _ = Describe("Manager", func() {
 				Representor: "dummylink",
 				PFName:      "enp175s0f1",
 				VFID:        0,
+				Trunk:       []int{4, 6},
 			}
 			// Mute logger
 			zerolog.SetGlobalLevel(zerolog.Disabled)
@@ -331,7 +332,10 @@ var _ = Describe("Manager", func() {
 				bridge := args.Get(1).(netlink.Link)
 				link.Attrs().MasterIndex = bridge.Attrs().Index
 			}).Return(nil)
+			mockedNl.On("BridgeVlanDel", fakeLink, uint16(1), true, true, false, true).Return(nil)
 			mockedNl.On("BridgeVlanAdd", fakeLink, uint16(100), true, true, false, true).Return(nil)
+			mockedNl.On("BridgeVlanAdd", fakeLink, uint16(4), false, false, false, true).Return(nil)
+			mockedNl.On("BridgeVlanAdd", fakeLink, uint16(6), false, false, false, true).Return(nil)
 
 			m := manager{nLink: mockedNl, sriov: mockedSr}
 			err := m.AttachRepresentor(netconf)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,6 +11,13 @@ type VfState struct {
 	EffectiveMAC string `json:"effective_mac"`
 }
 
+// Trunk represents configuration options for VLAN trunk
+type Trunk struct {
+	MinID *int `json:"minID,omitempty"`
+	MaxID *int `json:"maxID,omitempty"`
+	ID    *int `json:"id,omitempty"`
+}
+
 // NetConf extends types.NetConf for accelerated-bridge-cni
 // defines accelerated-bridge-cni public API
 type NetConf struct {
@@ -21,6 +28,8 @@ type NetConf struct {
 	Bridge string `json:"bridge,omitempty"`
 	// VLAN ID for VF
 	Vlan int `json:"vlan,omitempty"`
+	// VLAN Trunk configuration
+	Trunk []Trunk `json:"trunk"`
 	// MAC as top level config option; required for CNIs that don't support runtimeConfig
 	MAC string `json:"mac,omitempty"`
 	// PCI address of a VF in valid sysfs format
@@ -45,4 +54,6 @@ type PluginConf struct {
 	VFID int `json:"vfid"`
 	// VF names after in the container; used during deletion
 	ContIFNames string `json:"cont_if_names"`
+	// Internal presentation of VLAN Trunk config; we don't need this option in cache
+	Trunk []int `json:"-"`
 }


### PR DESCRIPTION
Add `trunk` configuration option.
This option allows configuring multiple allowed VLANs for VF
port.
Example:
`[{"id": 42}, {"minID": 100, "maxID": 103}]`
This will allow VLANs 42,100,101,102,103

It is possible to use `vlan` and `trunk` options together.
In this case, VLAN ID from `vlan` option will be used as
"native" VLAN for VF.


PR built on top of commits from https://github.com/Mellanox/accelerated-bridge-cni/pull/12, need to rebase before merge